### PR TITLE
Adds key mangling features.

### DIFF
--- a/upsilonconf/io.py
+++ b/upsilonconf/io.py
@@ -69,7 +69,7 @@ def save_json(
 def load_yaml(path: Path) -> Mapping[str, Any]:
     """
     Read config from a YAML file.
-key_modifiers
+
     Parameters
     ----------
     path : Path

--- a/upsilonconf/io.py
+++ b/upsilonconf/io.py
@@ -226,9 +226,8 @@ def _get_io_function(path: Path, write: bool = False):
 
 
 def __replace_in_keys(
-        dictionary: Union[Dict[str, Any], list, Any],
-        s: str,
-        r: str) -> Union[Dict[str, Any], list, Any]:
+    dictionary: Union[Dict[str, Any], list, Any], s: str, r: str
+) -> Union[Dict[str, Any], list, Any]:
     """
     Take a list or dictionary and replace all occurrencies of `s` in any of its
     keys with `r`.
@@ -272,8 +271,8 @@ def __replace_in_keys(
 
 
 def _replace_in_keys(
-        config: Mapping[str, Any],
-        key_modifiers: Dict[str, str]) -> Dict[str, Any]:
+    config: Mapping[str, Any], key_modifiers: Dict[str, str]
+) -> Dict[str, Any]:
     """
     Replace strings in the keys of a mapping object.
 
@@ -298,9 +297,7 @@ def _replace_in_keys(
     return _config
 
 
-def load(
-        path: Union[Path, str],
-        key_modifiers: Dict[str, str] = {}) -> Configuration:
+def load(path: Union[Path, str], key_modifiers: Dict[str, str] = {}) -> Configuration:
     """
     Read configuration from a file or directory.
 
@@ -325,9 +322,10 @@ def load(
 
 
 def save(
-        config: Mapping[str, Any],
-        path: Union[Path, str],
-        key_modifiers: Dict[str, str] = {}) -> None:
+    config: Mapping[str, Any],
+    path: Union[Path, str],
+    key_modifiers: Dict[str, str] = {},
+) -> None:
     """
     Write configuration to a file or directory.
 

--- a/upsilonconf/io.py
+++ b/upsilonconf/io.py
@@ -256,7 +256,7 @@ def __replace_in_keys(
         try:
             # Call this method recursively
             value = __replace_in_keys(value, s, r)
-        except Exception:
+        except AttributeError:
             # `value` is not of the mapping type
             pass
         dictionary[key.replace(s, r)] = value

--- a/upsilonconf/io.py
+++ b/upsilonconf/io.py
@@ -226,11 +226,11 @@ def _get_io_function(path: Path, write: bool = False):
 
 
 def __replace_in_keys(
-    dictionary: Union[Mapping[str, Any], list, Any], s: str, r: str
-) -> Union[Mapping[str, Any], list, Any]:
+    mapping: Union[Mapping[str, Any], Any], s: str, r: str
+) -> Union[Mapping[str, Any], Any]:
     """
-    Take a list or dictionary and replace all occurrencies of `s` in any of its
-    keys with `r`.
+    Take a mapping object and replace all occurrencies of `s` with `r` in any
+    of its keys.
 
     This function is called recursively.
 
@@ -239,35 +239,29 @@ def __replace_in_keys(
 
     Parameters
     ----------
-    dictionary : dict|list
-        The list or dictionary to be modified.
+    mapping : Mapping
+        The mapping object to be modified.
     s : str
-        The string to be replaced.
+        The string to be replaced in the keys.
     r : str
         The replacement string.
 
     Returns
     -------
-        The object of the same type with all strings `s` replaced by `r`.
+        The dictionary with all strings `s` replaced with `r` in the keys.
     """
-    # For lists perform this method on every object
-    if isinstance(dictionary, list):
-        return [__replace_in_keys(item, s, r) for item in dictionary]
+    # Traverse all the keys and replace `s` with `r`
+    dictionary = {}
+    for key, value in mapping.items():
+        try:
+            # Call this method recursively
+            value = __replace_in_keys(value, s, r)
+        except Exception:
+            # `value` is not of the mapping type
+            pass
+        dictionary[key.replace(s, r)] = value
 
-    # For dictionaries traverse all the keys and replace 's' with 'r'
-    elif isinstance(dictionary, dict):
-        final_dict = {}
-        for key, value in dictionary.items():
-            if isinstance(dictionary[key], (dict, list)):
-                # If a sub dictionary or a list call this method recursively
-                value = __replace_in_keys(value, s, r)
-            final_dict[key.replace(s, r)] = value
-
-        return final_dict
-
-    # By default return the same object
-    else:
-        return dictionary
+    return dictionary
 
 
 def _replace_in_keys(

--- a/upsilonconf/io.py
+++ b/upsilonconf/io.py
@@ -297,7 +297,9 @@ def _replace_in_keys(
     return _config
 
 
-def load(path: Union[Path, str], key_modifiers: Mapping[str, str] = {}) -> Configuration:
+def load(
+    path: Union[Path, str], key_modifiers: Mapping[str, str] = {}
+) -> Configuration:
     """
     Read configuration from a file or directory.
 

--- a/upsilonconf/io.py
+++ b/upsilonconf/io.py
@@ -293,7 +293,7 @@ def _replace_in_keys(
     _config = config
     # Replace longest strings first
     # - `sorted(..., reverse=True)` takes care of that
-    for key in sorted(key_modifiers.keys(), reverse=True):
+    for key in sorted(key_modifiers.keys(), key=lambda k: len(k), reverse=True):
         _config = __replace_in_keys(_config, key, key_modifiers[key])
     return _config
 

--- a/upsilonconf/io.py
+++ b/upsilonconf/io.py
@@ -1,7 +1,7 @@
 import json
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import Union, Any, Sequence, Mapping, Callable, overload, Tuple, Dict
+from typing import Union, Any, Sequence, Mapping, Callable, overload, Tuple
 
 from .config import Configuration
 from ._optional_dependency import optional_dependency_to
@@ -226,8 +226,8 @@ def _get_io_function(path: Path, write: bool = False):
 
 
 def __replace_in_keys(
-    dictionary: Union[Dict[str, Any], list, Any], s: str, r: str
-) -> Union[Dict[str, Any], list, Any]:
+    dictionary: Union[Mapping[str, Any], list, Any], s: str, r: str
+) -> Union[Mapping[str, Any], list, Any]:
     """
     Take a list or dictionary and replace all occurrencies of `s` in any of its
     keys with `r`.
@@ -271,8 +271,8 @@ def __replace_in_keys(
 
 
 def _replace_in_keys(
-    config: Mapping[str, Any], key_modifiers: Dict[str, str]
-) -> Dict[str, Any]:
+    config: Mapping[str, Any], key_modifiers: Mapping[str, str]
+) -> Mapping[str, Any]:
     """
     Replace strings in the keys of a mapping object.
 
@@ -297,7 +297,7 @@ def _replace_in_keys(
     return _config
 
 
-def load(path: Union[Path, str], key_modifiers: Dict[str, str] = {}) -> Configuration:
+def load(path: Union[Path, str], key_modifiers: Mapping[str, str] = {}) -> Configuration:
     """
     Read configuration from a file or directory.
 
@@ -324,7 +324,7 @@ def load(path: Union[Path, str], key_modifiers: Dict[str, str] = {}) -> Configur
 def save(
     config: Mapping[str, Any],
     path: Union[Path, str],
-    key_modifiers: Dict[str, str] = {},
+    key_modifiers: Mapping[str, str] = {},
 ) -> None:
     """
     Write configuration to a file or directory.


### PR DESCRIPTION
Strings in configuration keys can be modified by using the `key_modifiers` parameter in the `load()` and `save()` functions.

May I leave updating the `README.md` and adding tests to you? I believe you know better where to add this in the documentation and I admit that I am very bad in writing tests. Sorry.

As discussed in #2.