### PR TITLE
Dict conversion

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -714,7 +714,7 @@ class TestConfiguration(TestCase):
         ref = Configuration(key01="with space", key_2="with hyphen")
         self.assertEqual(ref, conf)
 
-        key_mods = {"-": "_", " ": "-"}  # reversed
+        key_mods = {"-": "_", " ": "0"}  # reversed
         conf = Configuration.from_dict(d, key_mods)
         ref = Configuration(key01="with space", key_2="with hyphen")
         self.assertEqual(ref, conf)

--- a/upsilonconf/config.py
+++ b/upsilonconf/config.py
@@ -476,11 +476,8 @@ def _modify_keys(
 
     """
     # Build and compile replacement pattern
-    pattern = re.compile(
-        "|".join(
-            [re.escape(k) for k in sorted(key_mods, key=lambda k: len(k), reverse=True)]
-        )
-    )
+    sorted_mod_keys = sorted(key_mods, key=lambda k: len(k), reverse=True)
+    pattern = re.compile("|".join([re.escape(k) for k in sorted_mod_keys]))
 
     return __modify_keys(mapping, key_mods, pattern)
 

--- a/upsilonconf/config.py
+++ b/upsilonconf/config.py
@@ -422,7 +422,7 @@ def _replace_in_keys(
        underscore and a space with a hyphen (and not an underscore).
     """
     if not key_modifiers:
-        return config
+        return dict(config)
 
     # To achieve the replacement strategy, we need a two step process (or
     # regular expressions):
@@ -456,4 +456,4 @@ def _replace_in_keys(
     for char, value in zip(chars, key_modifiers.values()):
         _config = __replace_in_keys(_config, char, value)
 
-    return dict(_config)
+    return _config

--- a/upsilonconf/config.py
+++ b/upsilonconf/config.py
@@ -8,7 +8,6 @@ from typing import (
     Union,
     Tuple,
     Mapping,
-    Callable,
     Dict,
 )
 

--- a/upsilonconf/config.py
+++ b/upsilonconf/config.py
@@ -9,6 +9,7 @@ from typing import (
     Tuple,
     Mapping,
     Dict,
+    Pattern,
 )
 
 __all__ = ["Configuration", "InvalidKeyError"]
@@ -483,7 +484,7 @@ def _modify_keys(
 
 
 def __modify_keys(
-    mapping: Mapping[str, Any], key_mods: Mapping[str, str], pattern
+    mapping: Mapping[str, Any], key_mods: Mapping[str, str], pattern: Pattern
 ) -> Dict[str, Any]:
     """
     Replace strings in the keys of a mapping object.

--- a/upsilonconf/config.py
+++ b/upsilonconf/config.py
@@ -485,11 +485,14 @@ def _modify_keys(
     return __modify_keys(mapping, key_mods, pattern)
 
 
-def __modify_keys(mapping: Mapping[str, Any], key_mods: Mapping[str, str], pattern):
+def __modify_keys(
+    mapping: Mapping[str, Any], key_mods: Mapping[str, str], pattern
+) -> Dict[str, Any]:
     """
     Replace strings in the keys of a mapping object.
 
-    The replacement is done recursively.
+    This is the working horse for `_modify_keys` to do the replacement
+    recursively.
 
     Parameters
     ----------

--- a/upsilonconf/config.py
+++ b/upsilonconf/config.py
@@ -475,12 +475,11 @@ def _modify_keys(
     dict
         A dictionary with the modified keys.
 
-    Alternatives
-    ------------
-    See https://github.com/hoedt/upsilonconf/pull/6 for alternative
-    implementations (and a discussion about them) which do not use regular
-    expressions.
     """
+    # See https://github.com/hoedt/upsilonconf/pull/6 for alternative
+    # implementations (and a discussion about them) which do not use regular
+    # expressions.
+
     # Build and compile replacement pattern
     sorted_mod_keys = sorted(key_mods, key=lambda k: len(k), reverse=True)
     pattern = re.compile("|".join([re.escape(k) for k in sorted_mod_keys]))

--- a/upsilonconf/config.py
+++ b/upsilonconf/config.py
@@ -475,6 +475,11 @@ def _modify_keys(
     dict
         A dictionary with the modified keys.
 
+    Alternatives
+    ------------
+    See https://github.com/hoedt/upsilonconf/pull/6 for alternative
+    implementations (and a discussion about them) which do not use regular
+    expressions.
     """
     # Build and compile replacement pattern
     sorted_mod_keys = sorted(key_mods, key=lambda k: len(k), reverse=True)


### PR DESCRIPTION
Looks like #5 was closed by me trying to get the changes into my branch …

1. https://github.com/sphh/upsilonconf/commit/b732840d8bd700318e92cb40fd6d0a0122e1cc55 has the ‘classic’ two-step approach with your replacement strategy:
    - `_modify_string()` (probably not the best name, so please feel free to change it)
    - The function `__replace_in_keys` can be deleted here.

2. https://github.com/sphh/upsilonconf/commit/13371c8efb07e7b1e5e8bc6ad24cca340794e934 uses regular expressions for the replacement:
    - `_modify_string()` (probably not the best name, so please feel free to change it)
    - The function `__replace_in_keys` can be deleted here.

3. https://github.com/sphh/upsilonconf/commit/a6d4ed77900e54b793cddf9879c4d731c240dbd8 optimizes the regular expression approach by compiling the replacement pattern just once.

Looks, like approach 3. is the fastest (but it needs to import the `re` module).